### PR TITLE
#9 에서 잘못 오픈한 액세스 지시자 수정

### DIFF
--- a/Sources/WKJavaScriptController/WKJavaScriptController.swift
+++ b/Sources/WKJavaScriptController/WKJavaScriptController.swift
@@ -103,7 +103,7 @@ open class WKJavaScriptController: NSObject {
 
     fileprivate weak var webView: WKWebView?
 
-    open var bridges = [MethodBridge]()
+    open private(set) var bridges = [MethodBridge]()
 
     fileprivate var isInjectRequired = true
 


### PR DESCRIPTION
## 작업 내용

- `bridges` 프로퍼티를 외부에서 수정할 수 없도록 수정 했습니다.